### PR TITLE
Add commit tagging to release-package recipe

### DIFF
--- a/makefile
+++ b/makefile
@@ -21,5 +21,8 @@ test-release-package: build-package
 	python -m twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
 release-package: build-package
-	python -m twine upload dist/*
-
+	git checkout master && \
+	git pull origin master && \
+	git tag $(shell cat setup.py | tr "\n" " " | sed -E "s/.* VERSION = \"([0-9]+\.[0-9]+\.[0-9]+)\" .*/\1/g") && \
+	python -m twine upload dist/* && \
+	git push origin master --tags


### PR DESCRIPTION
This PR expands the recipe used for releasing the package on PyPI to include adding and pushing version tags. The version is pulled from `setup.py` so that is defined only once. If the version had not been upgraded for the release, the recipe will fail.