### PR TITLE
Remove old build before creating new build

### DIFF
--- a/makefile
+++ b/makefile
@@ -14,6 +14,7 @@ test:
 	pytest -v
 
 build-package:
+	rm -rf build dist && \
 	pip install --upgrade pip setuptools wheel twine && \
 	python setup.py sdist bdist_wheel
 


### PR DESCRIPTION
This PR updates the recipe used to build the package in order to avoid errors when makeing a release as previous package versions are already available in PyPI.